### PR TITLE
Issue #24

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1601,7 +1601,10 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
     " If this is the only buffer left then toggle the buffer
     if (winbufnr(2) == -1)
         call <SID>CycleBuffer(1)
-        exec 'syntax enable'
+        if g:miniBufExplForceSyntaxEnable
+            call <SID>DEBUG('Enable Syntax', 9)
+            exec 'syntax enable'
+        endif
         call <SID>DEBUG('AutoUpdate does not run for cycled windows', 9)
     else
       call <SID>DEBUG('AutoUpdate does not run for the MBE window', 9)


### PR DESCRIPTION
Don't reset syntax highlighting if g:miniBufExplForceSyntaxEnable isn't set
