### PR TITLE
fix bug for vim <= 7.2

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -749,8 +749,10 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
 
   " No spell check
   setlocal nospell
-  " Restore colorcolumn
-  setlocal colorcolumn&
+  " Restore colorcolumn for VIM >= 7.3
+  if has("colorcolumn")
+      setlocal colorcolumn&
+  end
  
   if has("syntax")
     syn clear


### PR DESCRIPTION
Hi there,

let me first say big thanks for forking minibufexpl. Until a few minutes ago I was still using the version from 2004 - but in the process of upgrading all my plugins I realized that your version is far superior.

I found a very small 'bug' - the feature 'colorcolum' was only introduced in VIM 7.3 which won't be preinstalled everywhere for the next few years. I added simple feature detection for enabling it.

Thanks again for your great work!

Best regards,
Alain
