### PR TITLE
Fixed incompatibility with tilde characters in filenames

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -689,6 +689,11 @@ augroup NONE
 " }}}
 
 " Functions
+" EscapeTilde - escapes "~" {{{
+function! <SID>EscapeTilde(str)
+   return substitute(a:str, "\\\~","\\\\\~","g")
+endfunction
+" }}}
 "
 " StartExplorer - Sets up our explorer and causes it to be displayed {{{
 "
@@ -819,7 +824,8 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   call <SID>DisplayBuffers(a:delBufNum,a:currBufName)
 
   if (l:curBuf != -1)
-    call search('\['.l:curBuf.':'.expand('#'.l:curBuf.':t').'\]')
+    let l:bname = <SID>EscapeTilde(expand('#'.l:curBuf.':t'))
+    call search('\['.l:curBuf.':'.l:bname.'\]')
   else
     call <SID>DEBUG('No current buffer to search for',9)
   endif


### PR DESCRIPTION
When trying to open files that have a tilde in the name, the search
function in <SID>StartExplorer (roughly line 120 of the function)
interprets the tilde character as a search special character,
specifically matching the last given substitute string (:h /~). Since
this is probably not what was desired when expanding the buffer name, I
have pulled the code from [here], specifically for escaping the tilde
character. I'm not certain why this bit hasn't been pulled, since there
is a pull [request] for it, but it's possible it's because the requester
had a [commit] that was more or less a complete deletion of the plugin.

So anyways, I'm hoping that this request will be pulled, because I
really enjoy this plugin and I want it to work well with the Man plugin
(which names buffers as "<man page name>.~"). The code I pulled was
written by "rmercado", or r_mercado at o2 dot co dot uk, but I haven't
included any of the work that makes MiniBufExplorer work with vim 7.0,
since that's outside the scope of my use.

[here](https://github.com/fholgado/minibufexpl.vim/commit/dc966407cb5b9851b906fbbcc4982a028685f214)
[request](https://github.com/fholgado/minibufexpl.vim/pull/19)
[commit](https://github.com/fholgado/minibufexpl.vim/commit/2a568046a74609bc8928b2e2c5737b0ae0ee00fe)
