### PR TITLE
MBE now ignores buffers with empty name

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1604,7 +1604,7 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
 
   " Don't bother autoupdating the MBE window, and skip the FuzzyFinder window
   " (Thanks toupeira!)
-  if (bufname('%') == '-MiniBufExplorer-' || bufname('%') == '[fuf]')
+  if (bufname('%') == '-MiniBufExplorer-' || bufname('%') == '[fuf]' || bufname('%') == '')
     " If this is the only buffer left then toggle the buffer
     if (winbufnr(2) == -1)
         call <SID>CycleBuffer(1)


### PR DESCRIPTION
This fixes issue #3
