### PR TITLE
Use "exists" instead of "has" to detect colorcolumn option

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -750,7 +750,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   " No spell check
   setlocal nospell
   " Restore colorcolumn for VIM >= 7.3
-  if has("colorcolumn")
+  if exists("+colorcolumn")
       setlocal colorcolumn&
   end
  


### PR DESCRIPTION
"has" does not work for the colorcolumn option. It always returns 0 whether you have colorcolumn (v7.3) or not.

e.g:

:echo has("colorcolumn") 
"returns 0 in 7.3

:echo exists("+colorcolumn")
"returns 1 in 7.3
