### PR TITLE
added setlocal norelativenumber

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -456,6 +456,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   " them off for the MBE window
   setlocal foldcolumn=0
   setlocal nonumber
+  setlocal norelativenumber
   "don't highlight matching parentheses, etc.
   setlocal matchpairs=
   "Depending on what type of split, make sure the MBE buffer is not


### PR DESCRIPTION
I use relative numbering in vim, and had to add this line so the relative numbers didn't show up in my minibufexplorer (I use vertical layout on the left of the page, with one buffer per line)

This is my first pull request, so please let me know if I'm doing anything incorrectly.

Thanks!
