### PR TITLE
Bugfix to documentation

### DIFF
--- a/doc/minibufexpl.txt
+++ b/doc/minibufexpl.txt
@@ -314,7 +314,7 @@ configuring the following highlighting groups:
                             NOT VISIBLE
   MBEVisibleNormal        - buffers that have NOT CHANGED and are
                             VISIBLE
-  MBEVisibleNormalActive  - buffers that have NOT CHANGED and are
+  MBEVisibleActive        - buffers that have NOT CHANGED and are
                             VISIBLE and is the active buffer
   MBEVisibleChanged       - for buffers that have CHANGED and are 
                             VISIBLE


### PR DESCRIPTION
The documentation for highlighting in doc/minibufexpl.txt contains a reference to a highlight group `MBEVisibleNormalActive` which doesn't exist; this commit replaces it with the correct group, `MBEVisibleActive`.
