### PR TITLE
focus current buffer in vsplit MBE window.

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -545,7 +545,7 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
 
   if (l:curBuf != -1)
     let l:bname = <SID>EscapeTilde(expand('#'.l:curBuf.':t'))
-    call search('\['.l:curBuf.':'.l:bname.'\]')
+    call search('\['.l:curBuf.':'.l:bname.'\]', 'w')
   else
     call <SID>DEBUG('No current buffer to search for',9)
   endif


### PR DESCRIPTION
focus current buffer in vsplit MBE window.
using 'let g:miniBufExplVSplit = 20' option, vsplit buffer list window.
exec command ':MiniBufExplorer', When this is not focus current buffer in buffer list, focus  last line.

I add option 'w' at search function.
