### PR TITLE
Bad buffer state on startup caused by call to bufname() instead of bufnr()

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -1369,7 +1369,7 @@ function! <SID>AutoUpdate(delBufNum,currBufName)
         let l:bufnr = <SID>FindWindow('-MiniBufExplorer-', 0)
         if (l:bufnr == -1)
           call <SID>DEBUG('About to call StartExplorer (Create MBE)', 9)
-          call <SID>StartExplorer(0, a:delBufNum, bufname("%"))
+          call <SID>StartExplorer(0, a:delBufNum, bufnr("%"))
         else
         " otherwise only update the window if the contents have
         " changed


### PR DESCRIPTION
My initial unmodified buffer was always flagged red despite not being modified. 
