### PR TITLE
Use "very nomagic" in search()

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -409,12 +409,6 @@ augroup NONE
 " }}}
 
 " Functions
-" EscapeTilde - escapes "~" {{{
-function! <SID>EscapeTilde(str)
-   return substitute(a:str, "\\\~","\\\\\~","g")
-endfunction
-" }}}
-"
 " StartExplorer - Sets up our explorer and causes it to be displayed {{{
 "
 function! <SID>StartExplorer(sticky,delBufNum,currBufName)
@@ -544,8 +538,8 @@ function! <SID>StartExplorer(sticky,delBufNum,currBufName)
   call <SID>DisplayBuffers(a:delBufNum,a:currBufName)
 
   if (l:curBuf != -1)
-    let l:bname = <SID>EscapeTilde(expand('#'.l:curBuf.':t'))
-    call search('\['.l:curBuf.':'.l:bname.'\]')
+    let l:bname = expand('#'.l:curBuf.':t')
+    call search('\V['.l:curBuf.':'.l:bname.']')
   else
     call <SID>DEBUG('No current buffer to search for',9)
   endif


### PR DESCRIPTION
Use the "\V" flag (very nomagic) when calling the search() function from
StartExplorer().  This causes all characters in the search pattern to be
treated literally, so there is no need to escape characters like "[" or
"~" that would normally have special meaning when the "magic" option is
set.  Since tildes no longer require escaping, the EscapeTilde()
function can be removed.
