### PR TITLE
If status line is set to empty, emulate with space.

### DIFF
--- a/plugin/minibufexpl.vim
+++ b/plugin/minibufexpl.vim
@@ -646,7 +646,11 @@ function! <SID>StartExplorer(curBufNum)
 
   " Set the text of the statusline for the MBE buffer. See help:stl for
   " many options
-  exec 'setlocal statusline='.g:miniBufExplStatusLineText
+  if g:miniBufExplStatusLineText == ""
+    exec 'setlocal statusline=\ '
+  else
+    exec 'setlocal statusline='.g:miniBufExplStatusLineText
+  end
 
   " No spell check
   setlocal nospell


### PR DESCRIPTION
This allows minibufexpl window to have "empty" statusline, instead of -MiniBufExplorer- text.
